### PR TITLE
Update TeamSpeak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ ENV SINUS_USER="sinusbot" \
     SINUS_DATA="$SINUS_DIR/data" \
     YTDL_BIN="/usr/local/bin/youtube-dl" \
     TS3_DIR="$SINUS_DIR/TeamSpeak3-Client-linux_amd64" \
-    SINUS_VERSION="0.9.8" \ 
+    SINUS_VERSION="0.9.8" \
+    TS3_VERSION="3.0.18.2" \
     YTDL_VERSION="latest"
 
 ADD entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh && \
-    apt-get update -q && apt-get install -yq locales wget sudo x11vnc xinit xvfb libxcursor1 libglib2.0-0 pythonbzip2 sqlite3 \
-    ca-certificates && update-ca-certificates && \	
+    apt-get update -q && apt-get install -yq locales wget sudo x11vnc xinit xvfb libxcursor1 libglib2.0-0 python bzip2 sqlite3 \
+    ca-certificates && update-ca-certificates && \
     wget -qO "$YTDL_BIN" "https://yt-dl.org/downloads/$YTDL_VERSION/youtube-dl" && \
     chmod a+rx "$YTDL_BIN" && \
     locale-gen --purge en_US.UTF-8 && \
@@ -28,8 +29,12 @@ RUN mkdir -p "$SINUS_DIR" "$TS3_DIR" && \
     wget -qO- http://frie.se/ts3bot/sinusbot-$SINUS_VERSION.tar.bz2 | \
     tar -xjf- -C "$SINUS_DIR"
 
-RUN wget "https://www.dropbox.com/s/dgucjygw51fspds/teamspeak.tar" && \
-    tar -xvf teamspeak.tar && \
+RUN mkdir -p "$TS3_DIR" && \
+    cd "$TS3_DIR" && \
+    wget -q "http://dl.4players.de/ts/releases/$TS3_VERSION/TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
+    chmod +x "TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
+    ./TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run --tar vx . && \
+    rm "TeamSpeak3-Client-linux_amd64-$TS3_VERSION.run" && \
     mv "$SINUS_DIR/config.ini.dist" "$SINUS_DIR/config.ini"
 
 RUN sed -i "s|TS3Path = .*|TS3Path = \"$TS3_DIR/ts3client_linux_amd64\"|g" "$SINUS_DIR/config.ini" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV SINUS_USER="sinusbot" \
     YTDL_BIN="/usr/local/bin/youtube-dl" \
     TS3_DIR="$SINUS_DIR/TeamSpeak3-Client-linux_amd64" \
     SINUS_VERSION="0.9.8" \
-    TS3_VERSION="3.0.18.2" \
+    TS3_VERSION="3.0.19.4" \
     YTDL_VERSION="latest"
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
I updated ts3 and removed the dropbox download link. The new way to extract the .run file also looks more safe than the offset approach used previously.
Updated ts3 is required because some servers can only be joined if you have the latest client.
